### PR TITLE
Quotes the service path

### DIFF
--- a/.github/workflows/scan.yaml
+++ b/.github/workflows/scan.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: scan x64 archive from nightlies
         shell: cmd
         run: |
-            "C:\Program Files\Windows Defender\MpCmdRun.exe" -Scan -ScanType 3 -DisableRemediation -File "%CD%\nim.zip"
+            '"C:\Program Files\Windows Defender\MpCmdRun.exe" -Scan -ScanType 3 -DisableRemediation -File "%CD%\nim.zip"'
 
       - name: VirusTotal Scan
         uses: crazy-max/ghaction-virustotal@v3


### PR DESCRIPTION
This surrounds the entire command in quotes in order to avoid an unquoted service path. An unquoted service path is a common method of [privilege escalation](https://steflan-security.com/windows-privilege-escalation-unquoted-service-paths/). It looks like we did it with the first instance, just changing it for completeness.