### PR TITLE
Revert "Quotes the service path"

### DIFF
--- a/.github/workflows/scan.yaml
+++ b/.github/workflows/scan.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: scan x64 archive from nightlies
         shell: cmd
         run: |
-            '"C:\Program Files\Windows Defender\MpCmdRun.exe" -Scan -ScanType 3 -DisableRemediation -File "%CD%\nim.zip"'
+            "C:\Program Files\Windows Defender\MpCmdRun.exe" -Scan -ScanType 3 -DisableRemediation -File "%CD%\nim.zip"
 
       - name: VirusTotal Scan
         uses: crazy-max/ghaction-virustotal@v3


### PR DESCRIPTION
Reverts nim-lang/virus_checker#16

It doesn't seem to pass CI.

https://github.com/nim-lang/virus_checker/runs/8148740557?check_suite_focus=true

> The filename, directory name, or volume label syntax is incorrect.