### PR TITLE
feat: Add workflow to scan nim malware

### DIFF
--- a/.github/workflows/scan_malware.yml
+++ b/.github/workflows/scan_malware.yml
@@ -1,0 +1,35 @@
+name: Scan Nim malware with Windows Defender
+on:
+  pull_request:
+  push:
+  schedule:
+    - cron: '50 8 * * *'
+jobs:
+  run:
+    runs-on: windows-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+      - uses: jiro4989/setup-nim-action@v1
+        with:
+          nim-version: 'stable'
+      - run: git clone https://github.com/penguinite/nimalicious.git
+      - run: cd nimalicious && nimble build -d:yesReallyDestroyMyMachine -d:release -Y
+      - run: powershell Compress-Archive nimalicious\build\ virus.zip
+      - name: start Windows Defender service
+        shell: powershell
+        run: 'Set-Service -Name wuauserv -StartupType Manual -Status Running'
+      - name: update signatures
+        shell: cmd
+        run: '"C:\Program Files\Windows Defender\MpCmdRun.exe" -SignatureUpdate'
+      - name: scan virus built with Nim stable.
+        shell: cmd
+        run: |
+            "C:\Program Files\Windows Defender\MpCmdRun.exe" -Scan -ScanType 3 -DisableRemediation -File "%CD%\virus.zip"
+
+      - name: VirusTotal Scan
+        uses: crazy-max/ghaction-virustotal@v4
+        with:
+          vt_api_key: ${{ secrets.VT_API_KEY }}
+          files: |
+            virus.zip


### PR DESCRIPTION
This workflow clones the nimalicious github repository and builds it. It then scans it with Windows Defender and sends it to VirusTotal. Basically the same as scan.yml but with the nimalicious building steps on top.

It's alright if the binaries are all contained in a single archive since VirusTotal extracts the archive and scans each file individually, thus we can still see what viruses get detected by who.

Edit: Implements #11 